### PR TITLE
Add New Data Attribute to Disable Stars

### DIFF
--- a/starrr.coffee
+++ b/starrr.coffee
@@ -23,7 +23,7 @@
       @createStars()
       @syncRating()
 
-      return if @$connectedInput && @$connectedInput.is(':disabled')
+      return if @$connectedInput && @$connectedInput.is(':disabled') || @$el.data('disabled')
 
       @$el.on 'mouseover.starrr', 'i', (e) =>
         @syncRating(@getStars().index(e.currentTarget) + 1)
@@ -81,6 +81,3 @@
         data[option].apply(data, args)
 
 ) window.jQuery, window
-
-$ ->
-  $(".starrr").starrr()


### PR DESCRIPTION
Usage 

`<div class="starrr" data-rating='4'  data-disabled='true'></div>`

To make this more flexible with other library that uses `$`. I removed the line below so users will have to  manually called it

```
$(function() {
   return $(".starrr").starrr();
});
```
