### PR TITLE
Removed the Font Awesome dependency

### DIFF
--- a/src/starrr.coffee
+++ b/src/starrr.coffee
@@ -5,8 +5,8 @@
       rating: undefined
       max: 5
       readOnly: false
-      emptyClass: 'fa fa-star-o'
-      fullClass: 'fa fa-star'
+      emptyClass: 'glyphicon glyphicon-star-empty'
+      fullClass: 'glyphicon glyphicon-star'
       change: (e, value) ->
 
     constructor: ($el, options) ->


### PR DESCRIPTION
when pulling in bootstrap 3, just use the built in glyphicons